### PR TITLE
Remove ace-builds dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ace-builds"]
-	path = ace-builds
-	url = https://github.com/ajaxorg/ace-builds/

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 Notepad Utility for autowrapping
 
 ## HTML
-    git clone --recurse-submodules https://github.com/gesslar/mudpad
+    git clone https://github.com/gesslar/mudpad
 
 ## SSH
-
-    git clone --recurse-submodules git@github.com:gesslar/mudpad.git
+    git clone git@github.com:gesslar/mudpad.git
 
 test change


### PR DESCRIPTION
## Summary
- remove the ace-builds submodule and delete its directory
- update cloning instructions now that no submodules are required

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69269bcb6d3c83338c74a23634acbbe3)